### PR TITLE
Necessary breaking changes in core lib to use with Secret Network V1.7 after the mainnet upgrade

### DIFF
--- a/examples/SecretNET.Token.Examples/Program.cs
+++ b/examples/SecretNET.Token.Examples/Program.cs
@@ -103,7 +103,8 @@ else
     Console.ReadLine();
 }
 
-var gprcUrl = "https://grpc.testnet.secretsaturn.net"; // get from https://github.com/scrtlabs/api-registry
+//var gprcUrl = "https://grpc.testnet.secretsaturn.net"; // get from https://docs.scrt.network/secret-network-documentation/development/connecting-to-the-network
+var gprcUrl = "https://pulsar-2.api.trivium.network:9091"; // get from https://docs.scrt.network/secret-network-documentation/development/connecting-to-the-network
 var chainId = "pulsar-2";
 
 var createClientOptions = new CreateClientOptions(gprcUrl, chainId, wallet);
@@ -143,6 +144,7 @@ string snip20CodeHash = null;
 var snip20_code_id = snip20StoreCodeResponse.Response.CodeId;
 if (snip20_code_id > 0)
 {
+    snip20CodeHash = await secretClient.Query.Compute.GetCodeHashByCodeId(snip20_code_id);
 
     var snip20InstantiateOptions = new InstantiateSnip20()
     {
@@ -174,7 +176,7 @@ if (snip20_code_id > 0)
 
     Console.WriteLine("Snip20InstantiateOptions:\r\n" + JsonConvert.SerializeObject(snip20InstantiateOptions, Formatting.Indented) + "\r\n");
 
-    var msgInstantiateContract = new MsgInstantiate(snip20_code_id, $"MyFirstToken {snip20_code_id}", snip20InstantiateOptions);
+    var msgInstantiateContract = new MsgInstantiate(snip20_code_id, $"MyFirstToken {snip20_code_id}", snip20InstantiateOptions, codeHash: snip20CodeHash);
 
     var instantiateSnip20ContractResponse = await snip20Client.Tx.Instantiate(msgInstantiateContract, txOptionsUpload);
     logSecretTx("InstantiateTokenContract", instantiateSnip20ContractResponse);

--- a/src/SecretNET.Token.csproj
+++ b/src/SecretNET.Token.csproj
@@ -23,7 +23,7 @@
 		<PackageReadmeFile>NuGet_README.md</PackageReadmeFile>
 		<PackageIcon>SecretNetwork_Logo.png</PackageIcon>
 		<PackageTags>Token;Secret Network;Blockchain;Privacy;Cosmos-SDK;IBC;MAUI;Crypto;Web3;</PackageTags>
-		<Version>0.3.9-beta</Version>
+		<Version>0.3.9</Version>
 		<Title>SecretNET.Token is a layer on top of the SecretNET client (for the Secret Network Blockchain) which supports all methods of the reference implementation of the SNIP20 contract. </Title>
 		<Authors>Codemonkey</Authors>
 		<Description>SecretNET.Token is a layer on top of the Secret.NET which supports all methods of the reference implementation of the SNIP20 contract. The Secret Network blockchain (L1 / Cosmos), is the first privacy smart contract blockchain that processes and stores data on-chain in encrypted form (SGX). </Description>
@@ -43,7 +43,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="SecretNET" Version="0.3.11-beta" />
+	  <PackageReference Include="SecretNET" Version="0.3.11" />
 	</ItemGroup>
 
 

--- a/src/SecretNET.Token.csproj
+++ b/src/SecretNET.Token.csproj
@@ -23,11 +23,11 @@
 		<PackageReadmeFile>NuGet_README.md</PackageReadmeFile>
 		<PackageIcon>SecretNetwork_Logo.png</PackageIcon>
 		<PackageTags>Token;Secret Network;Blockchain;Privacy;Cosmos-SDK;IBC;MAUI;Crypto;Web3;</PackageTags>
-		<Version>0.3.8</Version>
+		<Version>0.3.9-beta</Version>
 		<Title>SecretNET.Token is a layer on top of the SecretNET client (for the Secret Network Blockchain) which supports all methods of the reference implementation of the SNIP20 contract. </Title>
 		<Authors>Codemonkey</Authors>
 		<Description>SecretNET.Token is a layer on top of the Secret.NET which supports all methods of the reference implementation of the SNIP20 contract. The Secret Network blockchain (L1 / Cosmos), is the first privacy smart contract blockchain that processes and stores data on-chain in encrypted form (SGX). </Description>
-		<PackageReleaseNotes>Update SecretNET Core Client (0.3.10)</PackageReleaseNotes>
+		<PackageReleaseNotes>Update SecretNET Core Client (0.3.11-beta)</PackageReleaseNotes>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -43,7 +43,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="SecretNET" Version="0.3.10" />
+	  <PackageReference Include="SecretNET" Version="0.3.11-beta" />
 	</ItemGroup>
 
 


### PR DESCRIPTION
# Older versions of Secret.NET will not work anymore!!

- Change key reading of the key used for transactions; update proto files
- Necessary for Secret Network V1.7